### PR TITLE
content: cut down header

### DIFF
--- a/file content encryption/README.md
+++ b/file content encryption/README.md
@@ -6,11 +6,12 @@
 
 Each file shall have a file header at offset 0 containing:
 
-* plaintext file signature identifying this file to be encrypted
-* file body offset
-* file key information
-* file body format (cipher mode, block size, ...)
-* tbd
+* Random 256-bit *FILE ID*
+ * This *FILE ID* **MUST** be mixed into each encrypted data block to tie that
+   block to the file. This make copying ciphertext blocks from one file
+   to another impossible.
+* **TO BE DECIDED** should the *FILE ID* be used as a per-file encryption key
+  by encrypting it with the *MASTER KEY*?
 
 ## File Body
 


### PR DESCRIPTION
Rather than continuing the discussion at
https://github.com/cryptomator/new-encryption-format/discussions , I would like to try make things more concrete via PRs like this one.

So please take this as an RFC i.e. a base for discussion.

For the fields I deleted:

* file body offset

This seems only be useful if the file is split into multiple parts. I don't think we want to do this, as it makes many operations non- atomic

* file key information

This seems to be covered already in what I called "FILE ID"

* file body format (cipher mode, block size, ...)

I don't think we want this configurable at a per-file level.

This should be fixed, or, if we need it configurable, it should be in the config file.