### PR TITLE
Add EOF Block to Authenticate File Size

### DIFF
--- a/file content encryption/README.md
+++ b/file content encryption/README.md
@@ -1,7 +1,5 @@
 # File Content Encryption
 
-:warning: this is a working draft
-
 ## File Header
 
 Each file shall have a file header at offset 0 containing:
@@ -35,5 +33,5 @@ This is an exhaustive list of file body formats that have been defined in this v
 All current and future formats must fulfil the following requirements:
 
 * The *BLOCK NUMBER* (first data block is *BLOCK NUMBER* zero) **MUST** be mixed into each encrypted data block.
-  This makes copying ciphertext blocks from one file to the same file at another location
-  impossible.
+  This makes copying ciphertext blocks from one file to the same file at another location impossible.
+* A zero-byte EOF block MUST be appended, if the preceding block is full (i.e. contains the maximum allowed number of bytes)

--- a/file content encryption/README.md
+++ b/file content encryption/README.md
@@ -33,5 +33,5 @@ This is an exhaustive list of file body formats that have been defined in this v
 All current and future formats must fulfil the following requirements:
 
 * The *BLOCK NUMBER* (first data block is *BLOCK NUMBER* zero) **MUST** be mixed into each encrypted data block.
-  This makes copying ciphertext blocks from one file to the same file at another location impossible.
+  This prohibits unnoticed tampering of block positions within a ciphertext file.
 * A zero-byte EOF block MUST be appended, if the preceding block is full (i.e. contains the maximum allowed number of bytes)


### PR DESCRIPTION
As proposed in #14, this change makes sure that files cannot end with "full blocks". The EOF block will have `n < blockSize` bytes or in other words: An EOF block with `n = blockSize` bytes is invalid.

This is necessary in order to protect the file from unnoticed truncation to `m * blockSize` bytes.

(also changed pseudocode to `ts` for better syntax highlighting support in GH)