### PR TITLE
Use `latestSeed` During Directory Creation

### DIFF
--- a/file name encryption/AES-SIV-512-B64URL.md
+++ b/file name encryption/AES-SIV-512-B64URL.md
@@ -1,33 +1,51 @@
 # File Name Encryption using AES-SIV-512 + Base64-URL-Encoding
 
-## Deriving Keys for File Name Encryption
+## Directory Metadata
 
-All file names are encrypted using AES-SIV, which requires a 512 bit key (which is internally split into two 256 bit AES keys). Furthermore we need a 256bit key for HMAC computations. So the first step is to look up the seed for file name encryption as denoted by the `initialSeed` and pass it through the [KDF](../kdf/README.md):
+Every directory requires certain metadata that affects the file name encryption of its direct children:
 
-```txt
-sivKey := kdf(secret: initialSeed, len: 64, context: "siv")
-hmacKey := kdf(secret: initialSeed, len: 32, context: "hmac")
-```
+* the seed used to derive keys
+* the directory ID
 
-## Directory IDs
-
-Every directory has a unique _directory ID_, which is defined to be a sequence of 32 random bytes (taking the birthday paradox into account, collision probability is therefore 2^-128). Directory IDs are immutable and therefore linked with a directory eternally, surviving renames/moves.
-
-```txt
-dirId = csprng(len: 32)
-```
-
-The only exception to this is the root directory ID, which is deterministically derived from the `initialSeed`:
-
-```txt
-rootDirId := kdf(secret: initialSeed, len: 32, context: "rootDirId")
-```
-
-The directory ID is stored in two places:
+This data is immutable and therefore linked with a directory eternally, surviving renames/moves. This data is stored in a file called `dir.uvf`, which is stored in two places:
 1. Within the parent dir (except for root), where it serves a link to the child dir
 2. In the child dir itself (allowing disaster recovery without the parent)
 
-The exact file structure to store the dir ID will be discussed in more detail below.
+The exact file structure to store the dir ID will be discussed in more detail [below](#format-of-diruvf-and-symlinkuvf).
+
+### Directory Seed
+
+At the time of its creation, a directory's seed is always the `latestSeed`. In case of the root directory this happens to also be the `initialSeed`.
+
+When navigating into a directory, the seed is read from the corresponding `dir.uvf`'s file header.
+
+> [!NOTE]
+> Child node names are encrypted with keys derived from their parent directory's seed. Due to the immutability, adding new child nodes to old parents will continue to use the old seed.
+>
+> Consequently, key rotation only affects child names of newly created directories.
+
+### Directory ID
+
+The directory ID is a unique sequence of 32 random bytes (taking the birthday paradox into account, collision probability is therefore 2^-128).
+
+```ts
+let dirId = csprng(len: 32)
+```
+
+The only exception to this is the root directory ID, which is deterministically derived from the `initialSeed` using the [KDF](../kdf/README.md):
+
+```ts
+let rootDirId = kdf(secret: initialSeed, len: 32, context: "rootDirId")
+```
+
+## Deriving Encryption Keys
+
+All file names are encrypted using AES-SIV, which requires a 512 bit key (which is internally split into two 256 bit AES keys). Furthermore we need a 256bit key for HMAC computations. We use the directory-specific seed from `dir.uvf` and feed it into the [KDF](../kdf/README.md):
+
+```ts
+let sivKey = kdf(secret: seed, len: 64, context: "siv")
+let hmacKey = kdf(secret: seed, len: 32, context: "hmac")
+```
 
 ## Mapping Directory IDs to Paths
 
@@ -37,10 +55,10 @@ When traversing directories, the directory ID of a given subdirectory is process
 1. Encoding the hash with Base32 to get a string of printable chars
 1. Constructing the directory path by resolving substrings of the encoded hash relative to the `{vaultRoot}/d/`
 
-```txt
-dirIdHash := hmacSha256(data: dirId, key: hmacKey)
-dirIdString := base32(dirIdHash)
-dirPath := vaultRoot + '/d/' + dirIdString[0..2] + '/' + dirIdString[2..32]
+```ts
+let dirIdHash = hmacSha256(data: dirId, key: hmacKey)
+let dirIdString = base32(dirIdHash)
+let dirPath = vaultRoot + '/d/' + dirIdString[0..2] + '/' + dirIdString[2..32]
 ```
 
 > [!NOTE]
@@ -62,9 +80,9 @@ The byte sequence is then encrypted using AES-SIV as defined in [RFC 5297](https
 
 Lastly, the ciphertext is encoded with unpadded base64url.
 
-```txt
-ciphertext := aesSiv(secret: cleartextName, ad: parentDirId, key: sivKey)
-ciphertextName := base64url(data: ciphertext) + '.uvf'
+```ts
+let ciphertext = aesSiv(secret: cleartextName, ad: parentDirId, key: sivKey)
+let ciphertextName = base64url(data: ciphertext) + '.uvf'
 ```
 
 ## Ciphertext Directory Structure
@@ -83,7 +101,7 @@ Depending on the kind of a cleartext node, the encrypted name is then either use
 
 Both, `dir.uvf` and `symlink.uvf` files are encrypted using the [content encryption mechanism](../file%20content%20encryption/README.md) configured for the vault.
 
-The cleartext content of `dir.uvf` is the 32 byte dirId.
+The cleartext content of `dir.uvf` is the 32 byte dirId. The seed to encrypt this file's header is the directory seed.
 
 The cleartext content of `symlink.uvf` is an UTF-8 string in Normalization Form C, denoting the cleartext target of the symlink.
 
@@ -128,25 +146,26 @@ Thus, for a given cleartext directory structure like this...
 
 #### List contents of `/`:
 
+1. Use `initialSeed` as a seed for the root directory
 1. compute `rootDirId` and corresponding ciphertext dir path -> `d/BZ/R4VZSS5PEF7TU3PMFIMON5GJRNBDWA`
-2. list direct children within `d/BZ/R4VZSS5PEF7TU3PMFIMON5GJRNBDWA`
+1. list direct children within `d/BZ/R4VZSS5PEF7TU3PMFIMON5GJRNBDWA`
     * `dir.uvf` (file)
     * `5TyvCyF255sRtfrIv83ucADQ.uvf` (file)
     * `FHTa55bHsUfVDbEb0gTL9hZ8nho.uvf` (dir)
     * `gLeOGMCN358UBf2Qk9cWCQl.uvf` (dir)
-3. For each subdirectory, determine node type
+1. For each subdirectory, determine node type
     * `FHTa55bHsUfVDbEb0gTL9hZ8nho.uvf` denotes a dir (contains `dir.uvf`)
     * `gLeOGMCN358UBf2Qk9cWCQl.uvf` denotes a symlink (contains `symlink.uvf`)
-4. strip file extension and decrypt file names
+1. strip file extension and decrypt file names
     * `File.txt`
     * `Subdirectory`
     * `Symlink`
 
 #### List contents of `/Subdirectory/`:
 
-1. decrypt file `d/BZ/R4VZSS5PEF7TU3PMFIMON5GJRNBDWA/FHTa55bHsUfVDbEb0gTL9hZ8nho.uvf/dir.uvf`
-2. read `dirId` from said file and compute ciphertext path -> `d/FC/ZKZRLZUODUUYTYA4457CSBPZXB5A77`
-3. Repeat dir listing procedure for `d/FC/ZKZRLZUODUUYTYA4457CSBPZXB5A77`
+1. read seed and decrypt `d/BZ/R4VZSS5PEF7TU3PMFIMON5GJRNBDWA/FHTa55bHsUfVDbEb0gTL9hZ8nho.uvf/dir.uvf`
+1. read `dirId` from said file and compute ciphertext path -> `d/FC/ZKZRLZUODUUYTYA4457CSBPZXB5A77`
+1. Repeat dir listing procedure for `d/FC/ZKZRLZUODUUYTYA4457CSBPZXB5A77`
 
 #### Read target of `/Symlink`:
 


### PR DESCRIPTION
Solely depending on the secrecy of the _directory ID_ to protect names of nodes added after rotating a key is not sufficient: The directory ID is irrelevant for the confidentiality during SIV decryption, because AD only affects the s2v function to check the authenticity.

Thus, this PR enhances privacy by actually rotating keys, i.e. every directory will now use the key referenced by the corresponding `dir.uvf` file.

(also changed pseudo code to ts for better syntax highlighting)