### PR TITLE
Switch to JWE JSON Serialization

### DIFF
--- a/vault metadata/README.md
+++ b/vault metadata/README.md
@@ -132,7 +132,7 @@ With this version of the UVF specification, the payload MUST contain at least th
 ```json
 {
     "fileFormat": "AES-256-GCM-32k",
-    "nameFormat": "AES-SIV-512-B64URL",
+    "nameFormat": "AES-256-SIV",
     "seeds": {
         "HDm3": "ypeBEsobvcr6wjGzmiPcTaeG7/gUfE5yuYB3ha/uSLs=",
         "cnQp": "PiPoFgA5WUoziU9lZOGxNIu9egCI1CxKy3PurtWcAJ0=",

--- a/vault metadata/README.md
+++ b/vault metadata/README.md
@@ -134,18 +134,14 @@ With this version of the UVF specification, the payload MUST contain at least th
     "fileFormat": "AES-256-GCM-32k",
     "nameFormat": "AES-256-SIV",
     "seeds": {
-        "HDm3": "ypeBEsobvcr6wjGzmiPcTaeG7/gUfE5yuYB3ha/uSLs=",
-        "cnQp": "PiPoFgA5WUoziU9lZOGxNIu9egCI1CxKy3PurtWcAJ0=",
-        "QBsJ": "Ln0sA6lQeuJl7PW1NWiFpTOTogKdJBOUmXJloaJa78Y="
+        "HDm38i": "ypeBEsobvcr6wjGzmiPcTaeG7/gUfE5yuYB3ha/uSLs=",
+        "gBryKw": "PiPoFgA5WUoziU9lZOGxNIu9egCI1CxKy3PurtWcAJ0=",
+        "QBsJFo": "Ln0sA6lQeuJl7PW1NWiFpTOTogKdJBOUmXJloaJa78Y="
     },
-    "latestFileKey": "QBsJ",
-    "nameKey": "HDm3",
+    "latestFileKey": "QBsJFo",
+    "nameKey": "HDm38i",
     "kdf": "HKDF-SHA512",
     "kdfSalt": "NIlr89R7FhochyP4yuXZmDqCnQ0dBB3UZ2D+6oiIjr8=",
     "org.example.customfield": 42
 }
 ```
-
-### Example / Test Data
-
-TODO: add example JWE and KEK

--- a/vault metadata/README.md
+++ b/vault metadata/README.md
@@ -65,6 +65,9 @@ With this version of the UVF specification, the following registered header para
 
 If required, further `alg`-specific header parameters MUST be added in the per-recipient unprotected header.
 
+> [!IMPORTANT]  
+> Even if only a single recipient exists, it MUST be added to the `recipients` array. Consequently, `alg` and `kid` MUST NOT neither be part of the `protected` nor the `unprotected` header.
+
 > [!NOTE]
 > In order to comply with [RFC 7516, Section 4.3](https://datatracker.ietf.org/doc/html/rfc7516#section-4.3), any UVF-specific parameters, such as `uvf.spec.version` MUST be prefixed with `uvf.`.
 > 

--- a/vault metadata/README.md
+++ b/vault metadata/README.md
@@ -74,8 +74,8 @@ If required, further `alg`-specific header parameters MUST be added in the per-r
 
 As the current version of this specification only allows for predefined parameter values, nothing but the parameter order may change. The base64url-encoded version of the protected header should therefore always be this:
 
-```txt
-eyJlbmMiOiJBMjU2R0NNIiwiY3R5IjoianNvbiIsImNyaXQiOlsidXZmLnNwZWMudmVyc2lvbiJdLCJ1dmYuc3BlYy52ZXJzaW9uIjoxfQ
+```json
+"protected": "eyJlbmMiOiJBMjU2R0NNIiwiY3R5IjoianNvbiIsImNyaXQiOlsidXZmLnNwZWMudmVyc2lvbiJdLCJ1dmYuc3BlYy52ZXJzaW9uIjoxfQ"
 ```
 
 #### Example Per-Recipient Unprotected Header


### PR DESCRIPTION
* allow multiple vault keys
* remove restriction on specific `alg`, allowing implementors to decide how to protect the CEK
* remove optional `typ` header parameter (any app reading this field already knows this is a JWE in JSON serialization)

related to #23