### PR TITLE
use 512 bit keys for HMAC-SHA256

### DIFF
--- a/file name encryption/AES-SIV-512-B64URL.md
+++ b/file name encryption/AES-SIV-512-B64URL.md
@@ -46,11 +46,11 @@ let rootDirId = kdf(secret: initialSeed, len: 32, context: "rootDirId")
 
 ## Deriving Encryption Keys
 
-All file names are encrypted using AES-SIV, which requires a 512 bit key (which is internally split into two 256 bit AES keys). Furthermore we need a 256 bit key for HMAC computations. We use the directory-specific seed from `dir.uvf` and feed it into the [KDF](../kdf/README.md):
+All file names are encrypted using AES-SIV, which requires a 512 bit key (which is internally split into two 256 bit AES keys). Furthermore we need a 512 bit key for HMAC computations. We use the directory-specific seed from `dir.uvf` and feed it into the [KDF](../kdf/README.md):
 
 ```ts
 let sivKey = kdf(secret: seed, len: 64, context: "siv")
-let hmacKey = kdf(secret: seed, len: 32, context: "hmac")
+let hmacKey = kdf(secret: seed, len: 64, context: "hmac")
 ```
 
 ## Mapping Directory IDs to Paths
@@ -238,7 +238,7 @@ flowchart TD
    kdfSiv{{"kdf(secret,64,'siv')"}}
    kdfSiv --> sivKey
    directorySeed -->|secret:| kdfHmac
-   kdfHmac{{"kdf(secret,32,'hmac')"}}
+   kdfHmac{{"kdf(secret,64,'hmac')"}}
    kdfHmac --> hmacKey
    hmacKey -->|key:| hmacSha256
    hmacSha256{{hmacSha256}}


### PR DESCRIPTION
When HKDF uses SHA-512, the native output size is 512 bit.

When HMAC uses SHA256, the internal block size is also 512 bit. If the key is shorter than the block size, it gets padded.

I.e. using a 256 bit key introduces unnecessary intermediate steps:

```mermaid
flowchart LR
  hkdf["HKDF-SHA512"] -->|"512 bit key"| truncate
  truncate -->|"256 bit key"| pad
  pad -->|"512 bit key"| hmac["HMAC-SHA256"]
```

So let's simplify this to:

```mermaid
flowchart LR
  hkdf["HKDF-SHA512"] -->|"512 bit key"| hmac["HMAC-SHA256"]
```

Not only does this remove unnecessary operations. Furthermore, truncating and then padding the key reduce the effective key size (assuming surrounding operations provide equally high security).